### PR TITLE
[FEAT] Mutant Crops

### DIFF
--- a/contracts/MutantCrops.sol
+++ b/contracts/MutantCrops.sol
@@ -1,0 +1,126 @@
+// contracts/MyContract.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+import "./GameOwner.sol";
+
+import "./Inventory.sol";
+
+contract MutantCrops is GameOwner, ERC721 {
+    using ECDSA for bytes32;
+
+    mapping(bytes32 => bool) public executed;
+
+    // Farm ID to saved timestamp
+    mapping(uint => uint) public mintedAt;
+
+    uint private inventoryId = 910;
+
+    uint public totalSupply = 0;
+
+    address private signer;
+
+    SunflowerLandInventory inventory;
+
+    constructor(SunflowerLandInventory _inventory) ERC721("Sunflower Land Mutant Crop", "SLM") {
+        inventory = _inventory;
+        signer = _msgSender();
+    }
+
+    function verify(bytes32 hash, bytes memory signature) private view returns (bool) {
+        bytes32 ethSignedHash = hash.toEthSignedMessageHash();
+        return ethSignedHash.recover(signature) == signer;
+    }
+
+    function mintSignature(
+        uint deadline,
+        uint cropId
+    ) private view returns(bytes32 success) {
+        /**
+         * Distinct order and abi.encode to avoid hash collisions
+         */
+        return keccak256(abi.encode(deadline, _msgSender(), cropId));
+    }
+
+    function mint(
+        // Verification
+        bytes memory signature,
+        uint deadline,
+        // Data
+        uint256 cropId
+    ) external returns(bool success) {
+        require(deadline >= block.timestamp, "MutantCrops: Deadline Passed");
+
+        // Verify
+        bytes32 txHash = mintSignature(deadline, cropId);
+        require(!executed[txHash], "MutantCrops: Tx Executed");
+        require(verify(txHash, signature), "MutantCrops: Unauthorised");
+        executed[txHash] = true;
+
+        require(nextMutantCrop() == cropId, "MutantCrops: Crop is not ready");
+
+        totalSupply += 1;
+
+        _mint(_msgSender(), totalSupply);
+        return true;
+    }
+
+    /**
+     * Cycle evenly one by one through the different crops
+     * Sunflower = 0
+     * Potato = 1
+     * ....
+     * Wheat = 9
+     */
+    function nextMutantCrop() public view returns (uint) {
+        return (totalSupply + 1) % 10;
+    }
+
+    /**
+     * Update it in the ERC1155 contract
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal override {
+        bool isMint = from == address(0);
+
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory amounts = new uint256[](1);
+
+        // Intialises the only element in the array
+        ids[0] = tokenId;
+        amounts[0] = 1;
+
+        if (isMint) {
+            // Mint it
+            inventory.gameMint(to, ids, amounts, "");
+        } else {
+            // Move it around
+            inventory.gameTransferFrom(from, to, ids, amounts, "");
+        }
+    }
+
+    /**
+     * Withdraw from farm to personal wallet
+     */
+    function gameTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public onlyGame {
+        _transfer(from, to, tokenId);
+    }
+
+    function gameMint(
+        address to,
+        uint256 tokenId
+    ) public onlyGame {
+        _mint(to, tokenId);
+    }
+}

--- a/contracts/MutantCrops.spec.ts
+++ b/contracts/MutantCrops.spec.ts
@@ -1,11 +1,34 @@
 import Web3 from "web3";
+import { encodeMutantCropFunction, MutantCropArgs } from "../src/signatures";
 import {
   TestAccount,
   deployMutantCropContracts,
   gasLimit,
 } from "./test-support";
 
-describe("Million on Mars contract", () => {
+enum Crops {
+  Sunflower = 0,
+  Potato = 1,
+  Pumpkin = 2,
+  Carrot = 3,
+  // ...
+}
+describe("Mutant Crops contract", () => {
+  // 20 minutes in future
+  const VALID_DEADLINE = Math.floor(new Date().getTime() / 1000) + 20 * 60;
+
+  async function sign(web3: Web3, args: MutantCropArgs) {
+    const sha = encodeMutantCropFunction({
+      ...args,
+    });
+    const { signature } = await web3.eth.accounts.sign(
+      sha,
+      TestAccount.TEAM.privateKey
+    );
+
+    return signature;
+  }
+
   it("deploys with total supply zero", async function () {
     const web3 = new Web3(
       new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
@@ -16,6 +39,373 @@ describe("Million on Mars contract", () => {
     expect(
       await mutantCrops.methods
         .totalSupply()
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("0");
+  });
+
+  it("sets the metadata uri correctly", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops } = await deployMutantCropContracts(web3);
+
+    await mutantCrops.methods.gameMint(TestAccount.PLAYER.address, 1).send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    expect(
+      await mutantCrops.methods
+        .tokenURI(1)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("https://sunflower-land.com/play/nfts/mutant-crops/1");
+
+    await mutantCrops.methods.setBaseUri("https://potato-land.com/").send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    expect(
+      await mutantCrops.methods
+        .tokenURI(1)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("https://potato-land.com/1");
+  });
+
+  it("ensures transaction is run in the deadline", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops } = await deployMutantCropContracts(web3);
+
+    // 6 minutes ago
+    const expiredDeadline = 0;
+    const signature = await sign(web3, {
+      cropId: Crops.Sunflower,
+      deadline: expiredDeadline,
+      sender: TestAccount.PLAYER.address,
+      farmId: 5,
+    });
+
+    const result = mutantCrops.methods
+      .mint(signature, expiredDeadline, Crops.Sunflower, 5)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    await expect(
+      result.catch((e: Error) => Promise.reject(e.message))
+    ).rejects.toContain("MutantCrops: Deadline Passed");
+  });
+
+  it("ensures transaction is verified by the game", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops } = await deployMutantCropContracts(web3);
+
+    const sha = encodeMutantCropFunction({
+      cropId: 1,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 5,
+    });
+
+    const { signature } = await web3.eth.accounts.sign(
+      sha,
+      // Sign by wrong entity
+      TestAccount.CHARITY.privateKey
+    );
+
+    const result = mutantCrops.methods
+      .mint(signature, VALID_DEADLINE, 1, 5)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    await expect(
+      result.catch((e: Error) => Promise.reject(e.message))
+    ).rejects.toContain("MutantCrops: Unauthorised");
+  });
+
+  it("ensures player owns the farm", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops, farm } = await deployMutantCropContracts(web3);
+
+    // Mint to different account
+    await farm.methods.mint(TestAccount.CHARITY.address).send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    const signature = await sign(web3, {
+      cropId: Crops.Sunflower,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 1,
+    });
+
+    const result = mutantCrops.methods
+      .mint(signature, VALID_DEADLINE, Crops.Sunflower, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    await expect(
+      result.catch((e: Error) => Promise.reject(e.message))
+    ).rejects.toContain("MutantCrops: You do not own this farm");
+  });
+
+  it("ensures crops get minted sequentially", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops, farm } = await deployMutantCropContracts(web3);
+
+    await farm.methods.mint(TestAccount.PLAYER.address).send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    const signature = await sign(web3, {
+      cropId: Crops.Potato,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 1,
+    });
+
+    const result = mutantCrops.methods
+      .mint(signature, VALID_DEADLINE, Crops.Potato, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    await expect(
+      result.catch((e: Error) => Promise.reject(e.message))
+    ).rejects.toContain("MutantCrops: Crop is not ready");
+  });
+
+  it("mints a mutant crop", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops, farm, inventory } = await deployMutantCropContracts(
+      web3
+    );
+
+    await farm.methods.mint(TestAccount.PLAYER.address).send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    const farmNFT = await farm.methods
+      .getFarm(1)
+      .call({ from: TestAccount.PLAYER.address });
+
+    const signature = await sign(web3, {
+      cropId: Crops.Sunflower,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 1,
+    });
+
+    await mutantCrops.methods
+      .mint(signature, VALID_DEADLINE, Crops.Sunflower, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    expect(
+      await mutantCrops.methods
+        .totalSupply()
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("1");
+
+    expect(
+      await mutantCrops.methods
+        .ownerOf(1)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual(farmNFT.account);
+
+    expect(
+      await mutantCrops.methods
+        .nextMutantCrop()
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("1");
+
+    expect(
+      await inventory.methods
+        .balanceOf(farmNFT.account, 912)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("1");
+  });
+
+  it("mints multiple mutant crops", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops, farm, inventory } = await deployMutantCropContracts(
+      web3
+    );
+
+    await farm.methods.mint(TestAccount.PLAYER.address).send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    const farmNFT = await farm.methods
+      .getFarm(1)
+      .call({ from: TestAccount.PLAYER.address });
+
+    const signature = await sign(web3, {
+      cropId: Crops.Sunflower,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 1,
+    });
+
+    await mutantCrops.methods
+      .mint(signature, VALID_DEADLINE, Crops.Sunflower, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    const signature2 = await sign(web3, {
+      cropId: Crops.Potato,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 1,
+    });
+
+    await mutantCrops.methods
+      .mint(signature2, VALID_DEADLINE, Crops.Potato, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    const signature3 = await sign(web3, {
+      cropId: Crops.Pumpkin,
+      deadline: VALID_DEADLINE,
+      sender: TestAccount.PLAYER.address,
+      farmId: 1,
+    });
+
+    await mutantCrops.methods
+      .mint(signature3, VALID_DEADLINE, Crops.Pumpkin, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    expect(
+      await mutantCrops.methods
+        .totalSupply()
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("3");
+
+    expect(
+      await mutantCrops.methods
+        .balanceOf(farmNFT.account)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("3");
+
+    expect(
+      await mutantCrops.methods
+        .nextMutantCrop()
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("3");
+
+    expect(
+      await inventory.methods
+        .balanceOf(farmNFT.account, 912)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("3");
+  });
+
+  it("transfers a mutant crop", async () => {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops, inventory } = await deployMutantCropContracts(web3);
+
+    await mutantCrops.methods.gameMint(TestAccount.PLAYER.address, 1).send({
+      from: TestAccount.TEAM.address,
+      gasPrice: await web3.eth.getGasPrice(),
+      gas: gasLimit,
+    });
+
+    expect(
+      await mutantCrops.methods
+        .ownerOf(1)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual(TestAccount.PLAYER.address);
+
+    expect(
+      await inventory.methods
+        .balanceOf(TestAccount.PLAYER.address, 912)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("1");
+
+    await mutantCrops.methods
+      .transferFrom(TestAccount.PLAYER.address, TestAccount.CHARITY.address, 1)
+      .send({
+        from: TestAccount.PLAYER.address,
+        gasPrice: await web3.eth.getGasPrice(),
+        gas: gasLimit,
+      });
+
+    expect(
+      await mutantCrops.methods
+        .ownerOf(1)
+        .call({ from: TestAccount.PLAYER.address })
+    ).toEqual(TestAccount.CHARITY.address);
+
+    expect(
+      await inventory.methods
+        .balanceOf(TestAccount.CHARITY.address, 912)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("1");
+
+    expect(
+      await inventory.methods
+        .balanceOf(TestAccount.PLAYER.address, 912)
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("0");
+
+    expect(
+      await inventory.methods
+        .balanceOf(TestAccount.PLAYER.address, 912)
         .call({ from: TestAccount.TEAM.address })
     ).toEqual("0");
   });

--- a/contracts/MutantCrops.spec.ts
+++ b/contracts/MutantCrops.spec.ts
@@ -1,0 +1,22 @@
+import Web3 from "web3";
+import {
+  TestAccount,
+  deployMutantCropContracts,
+  gasLimit,
+} from "./test-support";
+
+describe("Million on Mars contract", () => {
+  it("deploys with total supply zero", async function () {
+    const web3 = new Web3(
+      new Web3.providers.HttpProvider(process.env.ETH_NETWORK)
+    );
+
+    const { mutantCrops } = await deployMutantCropContracts(web3);
+
+    expect(
+      await mutantCrops.methods
+        .totalSupply()
+        .call({ from: TestAccount.TEAM.address })
+    ).toEqual("0");
+  });
+});

--- a/contracts/test-support.ts
+++ b/contracts/test-support.ts
@@ -105,8 +105,17 @@ export async function deployMutantCropContracts(web3: Web3) {
     web3,
     abijson.contracts["contracts/MutantCrops.sol:MutantCrops"],
     TestAccount.TEAM.address,
-    [farm.options.address]
+    [inventory.options.address, farm.options.address]
   );
+
+  await inventory.methods
+    .addGameRole(mutantCrops.options.address)
+    .send({ from: TestAccount.TEAM.address });
+
+  await farm.methods
+    .addGameRole(TestAccount.TEAM.address)
+    .send({ from: TestAccount.TEAM.address });
+
   return { farm, inventory, mutantCrops };
 }
 

--- a/contracts/test-support.ts
+++ b/contracts/test-support.ts
@@ -87,6 +87,29 @@ export async function deploySFLContracts(web3: Web3) {
   return { session, farm, token, inventory, beta, wishingWell };
 }
 
+export async function deployMutantCropContracts(web3: Web3) {
+  const [inventory, farm] = await Promise.all([
+    deployContract(
+      web3,
+      abijson.contracts["contracts/Inventory.sol:SunflowerLandInventory"],
+      TestAccount.TEAM.address
+    ),
+    deployContract(
+      web3,
+      abijson.contracts["contracts/Farm.sol:SunflowerLand"],
+      TestAccount.TEAM.address
+    ),
+  ]);
+
+  const mutantCrops = await deployContract(
+    web3,
+    abijson.contracts["contracts/MutantCrops.sol:MutantCrops"],
+    TestAccount.TEAM.address,
+    [farm.options.address]
+  );
+  return { farm, inventory, mutantCrops };
+}
+
 export async function deployWishingWellContracts(web3: Web3) {
   const [token, liquidityTestToken, farm] = await Promise.all([
     deployContract(

--- a/src/signatures.ts
+++ b/src/signatures.ts
@@ -103,6 +103,28 @@ export function encodeSyncFunction({
   );
 }
 
+export type MutantCropArgs = {
+  deadline: number;
+  sender: string;
+  farmId: number;
+  cropId: number;
+};
+
+export function encodeMutantCropFunction({
+  deadline,
+  sender,
+  farmId,
+  cropId,
+}: MutantCropArgs) {
+  const web3 = new Web3();
+  return web3.utils.keccak256(
+    web3.eth.abi.encodeParameters(
+      ["uint256", "address", "uint256", "uint256"],
+      [deadline, sender, cropId, farmId]
+    )
+  );
+}
+
 export type WishArgs = {
   deadline: number;
   sender: string;


### PR DESCRIPTION
This PR provides the smart contract functionality for mutant crops.

**Workflow**

- Server side generates a mutant crop transaction - Random Number Generator + Carrot Sword boost
- Client side executes the transaction
- Mutant Crop NFT is minted to Farm account
- Mutant Crop ERC1155 is minted to Farm inventory

**Rules**

Mutant crops must be minted sequentially. Sunflower then Potato then Pumpkin and so on.

This ensures an equal share of crops and high end crop farmers are equally rewarded.

**ERC721 + ERC1155**

We are using an ERC721 for uniqueness. For architecture purposes however, we want all data to live inside of the ERC1155 contract. This ensures that we don't have loose contracts and spaghetti code in the future trying to wrangle in data from a range of different sources.

When a Mutant Crop NFT is minted, the corresponding ERC1155 item is minted.

When a Mutant Crop NFT is transferred, the corresponding ERC1155 is transferred to the same address.

**An account can never directly trade the ERC1155 item, it will be non-withdrawable.**

_Open Sea_

Mutant Crops will show under the Collectibles collection. The image used will be a generic placeholder displaying 5 or 6 mutant crops. There will be a link that will then reference the NFT collection where users can see all the unique tokens and trade if they want.